### PR TITLE
Chore/15 update to latest python syntax

### DIFF
--- a/opentariff/models/product_models.py
+++ b/opentariff/models/product_models.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Optional
 from pydantic import BaseModel, Field, field_validator, ConfigDict, ValidationInfo
 
 from opentariff.Enums.product_enums import ProductEnums
@@ -12,7 +11,7 @@ class BundledProduct(BaseModel):
 
     type: ProductEnums.OtherProductsType
     name: str
-    description: Optional[str] = None
+    description: str | None = None
 
 
 class Product(BaseModel):
@@ -40,7 +39,7 @@ class Product(BaseModel):
 
     @field_validator("available_to")
     @classmethod
-    def validate_available_to(cls, v: Optional[datetime], info: ValidationInfo) -> Optional[datetime]:
+    def validate_available_to(cls, v: datetime | None, info: ValidationInfo) -> Optional[datetime]:
         if v and info.data.get("available_from") and v <= info.data["available_from"]:
             raise ValueError("available_to must be after available_from")
         return v

--- a/opentariff/models/product_models.py
+++ b/opentariff/models/product_models.py
@@ -22,21 +22,21 @@ class Product(BaseModel):
 
     name: str
     domestic: bool
-    description: Optional[str] = None
+    description: str | None = None
     type: ProductEnums.TariffType
     available_from: datetime
-    available_to: Optional[datetime] = None
-    supplier_name: Optional[str] = None
+    available_to: datetime | None = None
+    supplier_name: str | None = None
 
     # Optional Attributes
-    smart: Optional[bool] = None
-    ev: Optional[bool] = None
-    exclusive: Optional[bool] = None
-    retention: Optional[bool] = None
-    acquisition: Optional[bool] = None
-    collective_switch: Optional[bool] = None
-    green_percentage: Optional[float] = Field(None, ge=0, le=100)
-    bundled_products: Optional[list[BundledProduct]] = None
+    smart: bool | None = None
+    ev: bool | None = None
+    exclusive: bool | None = None
+    retention: bool | None = None
+    acquisition: bool | None = None
+    collective_switch: bool | None = None
+    green_percentage: float | None = Field(None, ge=0, le=100)
+    bundled_products: list[BundledProduct] | None = None
 
     @field_validator("available_to")
     @classmethod

--- a/opentariff/models/product_models.py
+++ b/opentariff/models/product_models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel, Field, field_validator, ConfigDict
+from pydantic import BaseModel, Field, field_validator, ConfigDict, ValidationInfo
 
 from opentariff.Enums.product_enums import ProductEnums
 
@@ -40,7 +40,7 @@ class Product(BaseModel):
 
     @field_validator("available_to")
     @classmethod
-    def validate_available_to(cls, v: Optional[datetime], info) -> Optional[datetime]:
+    def validate_available_to(cls, v: Optional[datetime], info: ValidationInfo) -> Optional[datetime]:
         if v and info.data.get("available_from") and v <= info.data["available_from"]:
             raise ValueError("available_to must be after available_from")
         return v

--- a/opentariff/models/product_models.py
+++ b/opentariff/models/product_models.py
@@ -39,7 +39,7 @@ class Product(BaseModel):
 
     @field_validator("available_to")
     @classmethod
-    def validate_available_to(cls, v: datetime | None, info: ValidationInfo) -> Optional[datetime]:
+    def validate_available_to(cls, v: datetime | None, info: ValidationInfo) -> datetime | None:
         if v and info.data.get("available_from") and v <= info.data["available_from"]:
             raise ValueError("available_to must be after available_from")
         return v

--- a/opentariff/models/tariff_models.py
+++ b/opentariff/models/tariff_models.py
@@ -1,6 +1,6 @@
 from datetime import datetime, date, time
 from decimal import Decimal
-from typing import Optional
+from typing import Self
 from pydantic import BaseModel, Field, field_validator, ConfigDict, model_validator
 
 from opentariff.Enums.base_enums import DayOfWeek
@@ -8,11 +8,11 @@ from opentariff.Enums.tariff_enums import TariffEnums
 
 
 class StandingCharge(BaseModel):
-    tcr_band: Optional[TariffEnums.TCRBand] = Field(default=None, ge=1, le=4)
-    tcrbandtype: Optional[TariffEnums.TCRBandType] = Field(default=None)
-    max_consumption: Optional[Decimal] = Field(default=None, gt=0)
-    min_consumption: Optional[Decimal] = Field(default=None, ge=0)
-    line_loss: Optional[Decimal] = Field(default=None, ge=0)
+    tcr_band: TariffEnums.TCRBand | None = Field(default=None, ge=1, le=4)
+    tcrbandtype: TariffEnums.TCRBandType | None = Field(default=None)
+    max_consumption: Decimal | None = Field(default=None, gt=0)
+    min_consumption: Decimal | None = Field(default=None, ge=0)
+    line_loss: Decimal | None = Field(default=None, ge=0)
     standing_charge: Decimal
 
 
@@ -26,47 +26,47 @@ class Rate(BaseModel):
     unit_rate: Decimal = Field(..., gt=0, lt=100)
 
     # Fields for time-of-use static rates
-    time_from: Optional[time] = None
-    time_to: Optional[time] = None
-    day_from: Optional[DayOfWeek] = None
-    day_to: Optional[DayOfWeek] = None
-    month_from: Optional[int] = Field(None, ge=1, le=12)
-    month_to: Optional[int] = Field(None, ge=1, le=12)
+    time_from: time | None = None
+    time_to: time | None = None
+    day_from: DayOfWeek | None = None
+    day_to: DayOfWeek | None = None
+    month_from: int | None = Field(None, ge=1, le=12)
+    month_to: int | None = Field(None, ge=1, le=12)
 
     # Fields for dynamic rates
-    rate_datetime: Optional[datetime] = None
+    rate_datetime: datetime | None = None
 
     # Fields for consumption-based rates
-    consumption_from: Optional[Decimal] = None
-    consumption_to: Optional[Decimal] = None
+    consumption_from: Decimal | None = None
+    consumption_to: Decimal | None = None
 
     # type of use static rates
-    consumption_type: Optional[TariffEnums.ConsumptionType] = None
+    consumption_type: TariffEnums.ConsumptionType | None = None
 
     @field_validator("time_to")
     @classmethod
-    def validate_time_to(cls, v: Optional[time], info) -> Optional[time]:
+    def validate_time_to(cls, v: time | None, info) -> time | None:
         if v and info.data.get("time_from") and v == info.data["time_from"]:
             raise ValueError("time_to must not equal time_from")
         return v
 
     @field_validator("day_to")
     @classmethod
-    def validate_day_to(cls, v: Optional[time], info) -> Optional[time]:
+    def validate_day_to(cls, v: time | None, info) -> time | None:
         if v and info.data.get("day_from") and v == info.data["day_from"]:
             raise ValueError("day_to must not equal day_from")
         return v
 
     @field_validator("month_to")
     @classmethod
-    def validate_month_to(cls, v: Optional[int], info) -> Optional[int]:
+    def validate_month_to(cls, v: int | None, info) -> int | None:
         if v and info.data.get("month_from") and v == info.data["month_from"]:
             raise ValueError("month_to must not equal to month_from")
         return v
 
     @field_validator("consumption_to")
     @classmethod
-    def validate_consumption_to(cls, v: Optional[Decimal], info) -> Optional[Decimal]:
+    def validate_consumption_to(cls, v: Decimal | None, info) -> Decimal| None:
         if (
             v
             and info.data.get("consumption_from")
@@ -78,7 +78,7 @@ class Rate(BaseModel):
         return v
 
     @model_validator(mode="after")
-    def validate_rate_fields(self):
+    def validate_rate_fields(self) -> Self:
         """Validate that required fields are present based on rate type"""
         rate_type = self.rate_type
         required_fields = TariffEnums.RateType.get_required_fields(rate_type)
@@ -100,14 +100,14 @@ class Tariff(BaseModel):
     rate_type: TariffEnums.RateType
     fuel_type: TariffEnums.FuelType
     payment_method: TariffEnums.PaymentMethod
-    contract_length_months: Optional[int] = Field(None, gt=0)
-    contract_end_date: Optional[date] = None
-    on_supply_from: Optional[datetime] = None
-    on_supply_to: Optional[datetime] = None
-    exit_fee_type: Optional[TariffEnums.ExitFeeType] = None
-    exit_fee_value: Optional[Decimal] = Field(None, ge=0)
-    supplier_tariff_code: Optional[str] = None
-    annual_cost: Optional[Decimal] = None
+    contract_length_months: int | None = Field(None, gt=0)
+    contract_end_date: date | None = None
+    on_supply_from: datetime | None = None
+    on_supply_to: datetime | None = None
+    exit_fee_type: TariffEnums.ExitFeeType | None = None
+    exit_fee_value: Decimal | None = Field(None, ge=0)
+    supplier_tariff_code: str | None = None
+    annual_cost: Decimal | None = None
     standing_charges: list[StandingCharge]
     rates: list[Rate]
 
@@ -124,7 +124,7 @@ class Tariff(BaseModel):
 
     @field_validator("exit_fee_value")
     @classmethod
-    def validate_exit_fee(cls, v: Optional[Decimal], info) -> Optional[Decimal]:
+    def validate_exit_fee(cls, v: Decimal | None, info) -> Decimal | None:
         if v is not None and not info.data.get("exit_fee_type"):
             raise ValueError(
                 "exit_fee_type is required when exit_fee_value is provided"

--- a/opentariff/models/tariff_models.py
+++ b/opentariff/models/tariff_models.py
@@ -1,7 +1,7 @@
 from datetime import datetime, date, time
 from decimal import Decimal
 from typing import Self
-from pydantic import BaseModel, Field, field_validator, ConfigDict, model_validator
+from pydantic import BaseModel, Field, field_validator, ConfigDict, model_validator, ValidationInfo
 
 from opentariff.Enums.base_enums import DayOfWeek
 from opentariff.Enums.tariff_enums import TariffEnums
@@ -45,28 +45,30 @@ class Rate(BaseModel):
 
     @field_validator("time_to")
     @classmethod
-    def validate_time_to(cls, v: time | None, info) -> time | None:
+    def validate_time_to(cls, v: time | None, info: ValidationInfo) -> time | None:
         if v and info.data.get("time_from") and v == info.data["time_from"]:
             raise ValueError("time_to must not equal time_from")
+        
         return v
 
     @field_validator("day_to")
     @classmethod
-    def validate_day_to(cls, v: time | None, info) -> time | None:
+    def validate_day_to(cls, v: time | None, info: ValidationInfo) -> time | None:
         if v and info.data.get("day_from") and v == info.data["day_from"]:
             raise ValueError("day_to must not equal day_from")
+        
         return v
 
     @field_validator("month_to")
     @classmethod
-    def validate_month_to(cls, v: int | None, info) -> int | None:
+    def validate_month_to(cls, v: int | None, info: ValidationInfo) -> int | None:
         if v and info.data.get("month_from") and v == info.data["month_from"]:
             raise ValueError("month_to must not equal to month_from")
         return v
 
     @field_validator("consumption_to")
     @classmethod
-    def validate_consumption_to(cls, v: Decimal | None, info) -> Decimal| None:
+    def validate_consumption_to(cls, v: Decimal | None, info: ValidationInfo) -> Decimal| None:
         if (
             v
             and info.data.get("consumption_from")
@@ -113,7 +115,7 @@ class Tariff(BaseModel):
 
     @field_validator("rates")
     @classmethod
-    def validate_rates(cls, v: list[Rate], info) -> list[Rate]:
+    def validate_rates(cls, v: list[Rate], info: ValidationInfo) -> list[Rate]:
         if not v:
             raise ValueError("tariff must have at least one rate")
         if "rate_type" in info.data:
@@ -124,7 +126,7 @@ class Tariff(BaseModel):
 
     @field_validator("exit_fee_value")
     @classmethod
-    def validate_exit_fee(cls, v: Decimal | None, info) -> Decimal | None:
+    def validate_exit_fee(cls, v: Decimal | None, info: ValidationInfo) -> Decimal | None:
         if v is not None and not info.data.get("exit_fee_type"):
             raise ValueError(
                 "exit_fee_type is required when exit_fee_value is provided"

--- a/opentariff/models/tariff_models.py
+++ b/opentariff/models/tariff_models.py
@@ -53,7 +53,7 @@ class Rate(BaseModel):
 
     @field_validator("day_to")
     @classmethod
-    def validate_day_to(cls, v: time | None, info: ValidationInfo) -> time | None:
+    def validate_day_to(cls, v: DayOfWeek | None, info: ValidationInfo) -> DayOfWeek | None:
         if v and info.data.get("day_from") and v == info.data["day_from"]:
             raise ValueError("day_to must not equal day_from")
         


### PR DESCRIPTION
# Description

Update to latest python type hint syntax.

## Changes

- Optional fields defined with this syntax int | None rather than Optional[int]
- Change to use Self type for when returning model in validation functions
- Add `ValidationInfo` type hint to the `info` argument in validation methods, this improves IDE suggestions and allows mypy to find when it is not used properly

## Other possible improvements

In the below validator method the type hint for the `day_to` is `time` perhaps this should be changed to `DayOfWeek` as the field on the model is defined as such.
```py
@field_validator("day_to")
@classmethod
def validate_day_to(cls, v: time | None, info: ValidationInfo) -> time | None:
    if v and info.data.get("day_from") and v == info.data["day_from"]:
        raise ValueError("day_to must not equal day_from")
    
    return v
```

However, if the validator is intended to be used with `time` objects then we should leave it as is.