### PR TITLE
add direction field and corresponding enums to Product and Rate

### DIFF
--- a/opentariff/Enums/product_enums.py
+++ b/opentariff/Enums/product_enums.py
@@ -11,3 +11,8 @@ class ProductEnums:
     class OtherProductsType(str, EnumBase):
         UTILITY = "utility"
         PHYSICAL_ASSET = "physical_asset"
+
+    class Direction(str, EnumBase):
+        IMPORT = "import"
+        EXPORT = "export"
+        BI_DIRECTIONAL = "bi_directional"

--- a/opentariff/Enums/tariff_enums.py
+++ b/opentariff/Enums/tariff_enums.py
@@ -54,3 +54,7 @@ class TariffEnums:
         ELECTRIC_VEHICLE = "electric_vehicle"
         HEAT_PUMP = "heat_pump"
         ANY = "any"
+
+    class RateDirection(str, EnumBase):
+        IMPORT = "import"
+        EXPORT = "export"

--- a/opentariff/models/product_models.py
+++ b/opentariff/models/product_models.py
@@ -26,6 +26,7 @@ class Product(BaseModel):
     available_from: datetime
     available_to: datetime | None = None
     supplier_name: str | None = None
+    direction: ProductEnums.Direction = ProductEnums.Direction.IMPORT
 
     # Optional Attributes
     smart: bool | None = None

--- a/opentariff/models/tariff_models.py
+++ b/opentariff/models/tariff_models.py
@@ -25,6 +25,9 @@ class Rate(BaseModel):
     fuel: TariffEnums.Fuel
     unit_rate: Decimal = Field(..., gt=0, lt=100)
 
+    #optional field for bidirectional tariffs
+    direction: TariffEnums.RateDirection | None = None
+
     # Fields for time-of-use static rates
     time_from: time | None = None
     time_to: time | None = None


### PR DESCRIPTION
# Description

Add direction field and corresponding enums to `Rate `and `Product` so that we can capture products that offer export rates in addition to imports.

## Changes
- Add product direction Enum with `import`, `export` and `bi_directional`
- Add direction field using Enum above which defaults to import, I have left it defaulting to import because presumably if this were left as `None` we would assume it was an `import` product anyway, having product objects with `None` as direction might be confusing if some have `import`
- Add `RateDirection` Enum with `import `and `export`
- Add direction field to `Rate`, currently this it optional with type `TariffEnums.RateDirection | None`. 

## Potential improvements
The direction field on the Rate model has been left as optional as that was requested in the issue, however, a similar argument applies to this as to the Product case. It might be better not to allow None as the type and instead set the default to `import` making the defnition more explicit. We would then potentially need a way to ensure any rate related to an `export` only Product was not unintentionally set to `import` by default.