### PR TITLE
remove rate_datetime for dynamic rates and add datetime_from, datetime_to instead 

### DIFF
--- a/opentariff/Enums/tariff_enums.py
+++ b/opentariff/Enums/tariff_enums.py
@@ -25,7 +25,7 @@ class TariffEnums:
             requirements = {
                 cls.SINGLE_RATE: [],
                 cls.TIME_OF_USE_STATIC: ["time_from", "time_to"],
-                cls.TIME_OF_USE_DYNAMIC: ["rate_datetime"],
+                cls.TIME_OF_USE_DYNAMIC: ["datetime_from", "datetime_to"],
                 cls.DEMAND_TIERED: ["consumption_from", "consumption_to"],
                 cls.TYPE_OF_USE: ["consumption_type"],
             }

--- a/opentariff/models/tariff_models.py
+++ b/opentariff/models/tariff_models.py
@@ -37,7 +37,8 @@ class Rate(BaseModel):
     month_to: int | None = Field(None, ge=1, le=12)
 
     # Fields for dynamic rates
-    rate_datetime: datetime | None = None
+    datetime_from: datetime | None = None
+    datetime_to: datetime | None = None
 
     # Fields for consumption-based rates
     consumption_from: Decimal | None = None

--- a/tests/models/test_tariff_models.py
+++ b/tests/models/test_tariff_models.py
@@ -32,15 +32,15 @@ def test_validate_rate_type():
         "rate_type": TariffEnums.RateType.TIME_OF_USE_DYNAMIC,
         "fuel": "electricity",
         "unit_rate": 0.15,
-        "rate_datetime": datetime.now(),
+        "datetime_from": datetime.now() - timedelta(hours=0.5),
+        "datetime_to": datetime.now(),
     }
     dynamic_rate = Rate.model_validate(rate_dict)
     assert dynamic_rate.rate_type == "time_of_use_dynamic"
+    
 
-    assert dynamic_rate.rate_datetime is not None
-
-    # Now remove the rate_datetime and check for validation error
-    rate_dict.pop("rate_datetime")
+    # Now remove the datetime_from and check for validation error
+    rate_dict.pop("datetime_from")
     with pytest.raises(ValidationError) as exc_info:
         Rate.model_validate(rate_dict)
 


### PR DESCRIPTION
# Description

CLOSES #16

Instead of dynamic ToU rates being defined by a `rate_datetime` field and it being assumed it lasts for half an hour, we instead now define a `datetime_from` and `datetime_to` similar to krakens `valid_from` and `valid_to`.

This is different to the initial suggestion from the issue to use `time_from` and `time_to` which are already used by static ToU rates. This is because these static rates are defined in combination with a day of the week and month which is incompatible with a specific date in time. To avoid adding complexity in the day_from and day_to we simply define the two new datetime fields described above, this also matches more closely what Kraken does.

# Removed
- `rate_datetime` field from the Rate model

# Added
- `datetime_from` and `datetime_to` on the Rate model

# Changed
- Update `get_required_fields` for `validate_rate_fields` validator on the Rate model to use new field names
- Update validation tests to use new fields instead of `rate_datetime`

