### PR TITLE
Feature/18 update validation for static time of use

### DIFF
--- a/opentariff/Enums/tariff_enums.py
+++ b/opentariff/Enums/tariff_enums.py
@@ -19,12 +19,16 @@ class TariffEnums:
         TIME_OF_USE_DYNAMIC = "time_of_use_dynamic"
         DEMAND_TIERED = "demand_tiered"
         TYPE_OF_USE = "type_of_use"
-
+        
         @classmethod
         def get_required_fields(cls, rate_type) -> list[str]:
+            """Return a list of the fields required on a rate of rate_type.
+
+            TIME_OF_USE_STATIC rates are handled seperately. Look in the 
+            Rate.validate_static_tou_rate_fields() for TIME_OF_USE_STATIC behaviour.
+            """
             requirements = {
                 cls.SINGLE_RATE: [],
-                cls.TIME_OF_USE_STATIC: ["time_from", "time_to"],
                 cls.TIME_OF_USE_DYNAMIC: ["datetime_from", "datetime_to"],
                 cls.DEMAND_TIERED: ["consumption_from", "consumption_to"],
                 cls.TYPE_OF_USE: ["consumption_type"],

--- a/opentariff/models/tariff_models.py
+++ b/opentariff/models/tariff_models.py
@@ -93,22 +93,15 @@ class Rate(BaseModel):
         required_fields = []
         # Ensure the pairs [time_from,time_to], [day_from,day_to], [month_from, month_to]
         # Always appear together as a pair
-        if getattr(self, "time_from", None) is not None or getattr(self, "time_to", None) is not None:
+        if getattr(self, "time_from", None) or getattr(self, "time_to", None):
             required_fields.extend(["time_from", "time_to"])
 
-        if getattr(self, "day_from", None) is not None or getattr(self, "day_to", None) is not None:
+        if getattr(self, "day_from", None) or getattr(self, "day_to", None):
             required_fields.extend(["day_from", "day_to"])
 
-        if getattr(self, "month_from", None) is not None or getattr(self, "month_to", None) is not None:
+        if getattr(self, "month_from", None) or getattr(self, "month_to", None):
             required_fields.extend(["month_from", "month_to"])
-        
-        if required_fields and not all(
-            getattr(self, field, None) is not None for field in required_fields
-        ):
-            raise ValueError(f"Rate with {self.rate_type} require that each of the elements of "
-                             "the pairs [time_from,time_to], [day_from,day_to], "
-                             "[month_from, month_to] appear together.")
-        
+
         # Check we have at least one of the pairs
         if not required_fields:
             print("All time fields empty")
@@ -116,6 +109,13 @@ class Rate(BaseModel):
             raise ValueError(f"Rate with {self.rate_type} require at least "
                              "one of the pairs [time_from,time_to], [day_from,day_to], "
                              "[month_from, month_to]")
+        
+        if not all(
+            getattr(self, field, None) for field in required_fields
+        ):
+            raise ValueError(f"Rate with {self.rate_type} require that each of the elements of "
+                             "the pairs [time_from,time_to], [day_from,day_to], "
+                             "[month_from, month_to] appear together.")
         
         return self
     

--- a/opentariff/models/tariff_models.py
+++ b/opentariff/models/tariff_models.py
@@ -83,10 +83,53 @@ class Rate(BaseModel):
             )
         return v
 
+    def validate_static_tou_rate_fields(self) -> Self:
+        """For a static_tou rate use the rate itself to determine 
+        which fields are required. The rate should have at least 
+        one of the pairs [time_from,time_to], [day_from,day_to], 
+        [month_from, month_to] and each pair should should appear
+        with both elements"""
+
+        required_fields = []
+        # Ensure the pairs [time_from,time_to], [day_from,day_to], [month_from, month_to]
+        # Always appear together as a pair
+        if getattr(self, "time_from", None) is not None or getattr(self, "time_to", None) is not None:
+            required_fields.extend(["time_from", "time_to"])
+
+        if getattr(self, "day_from", None) is not None or getattr(self, "day_to", None) is not None:
+            required_fields.extend(["day_from", "day_to"])
+
+        if getattr(self, "month_from", None) is not None or getattr(self, "month_to", None) is not None:
+            required_fields.extend(["month_from", "month_to"])
+        
+        if required_fields and not all(
+            getattr(self, field, None) is not None for field in required_fields
+        ):
+            raise ValueError(f"Rate with {self.rate_type} require that each of the elements of "
+                             "the pairs [time_from,time_to], [day_from,day_to], "
+                             "[month_from, month_to] appear together.")
+        
+        # Check we have at least one of the pairs
+        if not required_fields:
+            print("All time fields empty")
+            # Required fields is empty means that None of the fields were present
+            raise ValueError(f"Rate with {self.rate_type} require at least "
+                             "one of the pairs [time_from,time_to], [day_from,day_to], "
+                             "[month_from, month_to]")
+        
+        return self
+    
     @model_validator(mode="after")
     def validate_rate_fields(self) -> Self:
         """Validate that required fields are present based on rate type"""
         rate_type = self.rate_type
+
+        # We handle static tou seperately becuase the required fields depend on
+        # which fields are present
+        if rate_type == TariffEnums.RateType.TIME_OF_USE_STATIC:
+            return self.validate_static_tou_rate_fields()
+        
+        # All other rate types have predictable required fields so we use a straightforward mapping
         required_fields = TariffEnums.RateType.get_required_fields(rate_type)
 
         if required_fields and not all(

--- a/tests/models/test_tariff_models.py
+++ b/tests/models/test_tariff_models.py
@@ -9,7 +9,22 @@ from opentariff.Enums.tariff_enums import TariffEnums
 
 
 def test_validate_rate_type():
-    """Test the field validator for rate_type works correctly"""
+    """Test the field validator for rate_type works correctly.
+
+    Static TOU (Test 1a-1d):
+    Should have at least one of the pairs
+    [time_from,time_to], [day_from,day_to], [month_from, month_to]
+    and each pair should should have both elements as not None.
+
+    Dynamic ToU (Test 2):
+    Should have both datetime_from and datetime_to.
+
+    Consumption based (Test 3):
+    Must have cunsumption_from and consumption_to.
+
+    Type of use rate (Test 4):
+    Must have consumption_type
+    """
     
     # Test 1: Static tou rate with time_from and time_to
     rate_dict = {
@@ -24,6 +39,69 @@ def test_validate_rate_type():
 
     # Now remove the time_to and check for validation error
     rate_dict.pop("time_to")
+    with pytest.raises(ValidationError) as exc_info:
+        Rate.model_validate(rate_dict)
+
+    # Test 1b: Static tou rate with day_from and day_to
+    rate_dict = {
+        "rate_type": TariffEnums.RateType.TIME_OF_USE_STATIC,
+        "fuel": "electricity",
+        "unit_rate": 0.15,
+        "day_from": 1,
+        "day_to": 5,
+    }
+    static_tou_rate = Rate.model_validate(rate_dict)
+    assert static_tou_rate.rate_type == "time_of_use_static"
+
+    # Now remove the day_to and check for validation error
+    rate_dict.pop("day_to")
+    with pytest.raises(ValidationError) as exc_info:
+        Rate.model_validate(rate_dict)
+
+    # Test 1c: Static tou rate with month_from and month_to
+    rate_dict = {
+        "rate_type": TariffEnums.RateType.TIME_OF_USE_STATIC,
+        "fuel": "electricity",
+        "unit_rate": 0.15,
+        "month_from": 3,
+        "month_to": 9,
+    }
+    static_tou_rate = Rate.model_validate(rate_dict)
+    assert static_tou_rate.rate_type == "time_of_use_static"
+
+    # Now remove the month_to and check for validation error
+    rate_dict.pop("month_to")
+    with pytest.raises(ValidationError) as exc_info:
+        Rate.model_validate(rate_dict)
+    
+    # Test 1d: Static tou rate with month_from, month_to,
+    # day_to, day_from, time_from and time_to
+    rate_dict = {
+        "rate_type": TariffEnums.RateType.TIME_OF_USE_STATIC,
+        "fuel": "electricity",
+        "unit_rate": 0.15,
+        "month_from": 3,
+        "month_to": 9,
+        "day_from": 1,
+        "day_to": 4,
+        "time_from": "00:00",
+        "time_to": "06:00",
+    }
+    static_tou_rate = Rate.model_validate(rate_dict)
+    assert static_tou_rate.rate_type == "time_of_use_static"
+
+    # Now remove the month_to and check for validation error
+    rate_dict.pop("month_to")
+    with pytest.raises(ValidationError) as exc_info:
+        Rate.model_validate(rate_dict)
+    
+    # Now remove the month_from and check for validation success
+    rate_dict.pop("month_from")
+    static_tou_rate = Rate.model_validate(rate_dict)
+    assert static_tou_rate.rate_type == "time_of_use_static"
+
+    # Now remove day_to and check we get validation error
+    rate_dict.pop("day_to")
     with pytest.raises(ValidationError) as exc_info:
         Rate.model_validate(rate_dict)
 

--- a/tests/models/test_tariff_models.py
+++ b/tests/models/test_tariff_models.py
@@ -42,6 +42,11 @@ def test_validate_rate_type():
     with pytest.raises(ValidationError) as exc_info:
         Rate.model_validate(rate_dict)
 
+    # Now remove the time_from (no time fields in data now) and check for validation error
+    rate_dict.pop("time_from")
+    with pytest.raises(ValidationError) as exc_info:
+        Rate.model_validate(rate_dict)
+
     # Test 1b: Static tou rate with day_from and day_to
     rate_dict = {
         "rate_type": TariffEnums.RateType.TIME_OF_USE_STATIC,


### PR DESCRIPTION
# Description

#CLOSES #18

Update validation for TIME_OF_USE_STATIC Rates.

Rate model should have at least one of the pairs [time_from,time_to], [day_from,day_to], [month_from, month_to] and each pair should should have both elements as not None.

I chose to add a seperate function on the Rate model rather than extend the exisiting `TariffEnums.RateType.get_required_fields` function, this is because the required fields for static tou depend on which fields were already present. So `get_required_fields` would need access to the rate model and so it was seperated out to prevent circular dependancy between `tariff_models.py` and `tariff_enums.py`.

# Added
- More tests on Rate model for static tou rates.
- New function to determine which fields are requred based on exisiting fields.

# Changed
- Model validator for Rate