### PR TITLE
Rename OtherProductsType to BundledWithType and add SERVICE value

### DIFF
--- a/opentariff/Enums/product_enums.py
+++ b/opentariff/Enums/product_enums.py
@@ -8,9 +8,14 @@ class ProductEnums:
         FIXED = "fixed"
         VARIABLE = "variable"
 
-    class OtherProductsType(str, EnumBase):
+    class BundledWithType(str, EnumBase):
+        """What a bundled product is bundled with, e.g. a utility,
+        a physical asset (solar panels, battery) or a service
+        (boiler care insurance)."""
+
         UTILITY = "utility"
         PHYSICAL_ASSET = "physical_asset"
+        SERVICE = "service"
 
     class Direction(str, EnumBase):
         IMPORT = "import"

--- a/opentariff/Enums/product_enums.py
+++ b/opentariff/Enums/product_enums.py
@@ -9,10 +9,10 @@ class ProductEnums:
         VARIABLE = "variable"
 
     class BundledWithType(str, EnumBase):
-        """What a bundled product is bundled with: a physical asset
+        """What a bundled product is bundled with: an asset
         (solar panels, battery) or a service (boiler care insurance)."""
 
-        PHYSICAL_ASSET = "physical_asset"
+        ASSET = "asset"
         SERVICE = "service"
 
     class Direction(str, EnumBase):

--- a/opentariff/Enums/product_enums.py
+++ b/opentariff/Enums/product_enums.py
@@ -9,11 +9,9 @@ class ProductEnums:
         VARIABLE = "variable"
 
     class BundledWithType(str, EnumBase):
-        """What a bundled product is bundled with, e.g. a utility,
-        a physical asset (solar panels, battery) or a service
-        (boiler care insurance)."""
+        """What a bundled product is bundled with: a physical asset
+        (solar panels, battery) or a service (boiler care insurance)."""
 
-        UTILITY = "utility"
         PHYSICAL_ASSET = "physical_asset"
         SERVICE = "service"
 

--- a/opentariff/models/product_models.py
+++ b/opentariff/models/product_models.py
@@ -9,7 +9,7 @@ class BundledProduct(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    type: ProductEnums.OtherProductsType
+    type: ProductEnums.BundledWithType
     name: str
     description: str | None = None
 


### PR DESCRIPTION
## Summary

- Renames `ProductEnums.OtherProductsType` to `ProductEnums.BundledWithType`. The old name was misleading: this enum describes what a product is bundled *with*, not a product category.
- Replaces the value set with two categories that reflect how products are bundled on the market:
  - `asset` - e.g. tariffs bundled with solar panels or a battery
  - `service` - e.g. tariffs bundled with Boiler Care Insurance
- Renames the previous `physical_asset` value to `asset`: the contrast with `service` already implies tangibility, and it matches industry vocabulary (behind-the-meter assets, flexibility assets, etc.).
- Removes the previous `utility` value: subscription-style bundles (broadband, mobile, etc.) are covered by `service`, and dual-fuel is a fuel attribute rather than a bundle.
- Updates `BundledProduct.type` in `opentariff/models/product_models.py` to use the renamed enum.

Note for consumers: this changes the serialized value `"physical_asset"` to `"asset"`, so any existing data using the old value will need migrating. A bundle type should only be present when a product is actually bundled (i.e. `bundled_products` is populated); standalone tariffs have no `BundledWithType`.

Closes #27

## Test plan

- [x] `pytest` passes (2 passed)
- [x] Repo-wide search confirms no remaining references to `OtherProductsType`, `utility` or `physical_asset`
